### PR TITLE
chore(deps): bump pnpm 10.33.0 -> 11.9.0 (clears the build-tool CVEs)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -53,37 +53,3 @@ CVE-2026-33671
 # (verify with `docker pull nginx:alpine && docker run --rm
 # nginx:alpine apk info libexpat`).
 CVE-2026-45186
-
-# ---------------------------------------------------------------------
-# pnpm itself (the pinned `packageManager`) — build/start-time only
-# ---------------------------------------------------------------------
-# `packages/api/Dockerfile` is single-stage node:24-alpine, so the
-# corepack-resolved pnpm (pinned `pnpm@10.33.0` in the root
-# package.json `packageManager`) ships in the runtime image and Trivy
-# flags it via the `package.json` scanner. Every one of these is a
-# "pnpm processes a MALICIOUS package / manifest / lockfile /
-# configDependency" class bug : arbitrary file write-delete, transitive
-# alias path traversal, manifest-identity spoof bypassing allowBuilds,
-# repo-controlled configDependencies, patch-remove file deletion,
-# env-lockfile short-circuit.
-#
-# Blast radius : in our image pnpm runs exactly twice and only over OUR
-# OWN committed inputs — `pnpm install --frozen-lockfile` at build (our
-# lockfile), then `pnpm db:migrate:docker && pnpm start:docker` at
-# container start (no install at all). It never resolves an attacker-
-# controlled package/manifest ; anyone who could inject one already owns
-# the repo. None of these is reachable through the running app's HTTP
-# surface.
-#
-# Drop criterion : bump pnpm to ≥ 11.8.0 (the first line that fixes ALL
-# of these — several, e.g. CVE-2026-55697, have NO 10.x backport) in a
-# dedicated upgrade PR where the lockfile + major bump get tested, then
-# delete this whole block.
-CVE-2026-50015
-CVE-2026-50016
-CVE-2026-55487
-CVE-2026-55697
-CVE-2026-55698
-GHSA-72r4-9c5j-mj57
-GHSA-fr4h-3cph-29xv
-GHSA-qrv3-253h-g69c

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "2.17.0",
   "license": "AGPL-3.0-or-later",
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.9.0",
   "scripts": {
     "dev:web": "pnpm --filter @nodea/web dev",
     "dev:api": "pnpm --filter @nodea/api dev",
@@ -35,29 +35,5 @@
     "lint-staged": "17.0.7",
     "typescript": "6.0.3",
     "typescript-eslint": "8.61.1"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "puppeteer"
-    ],
-    "overrides": {
-      "esbuild@<0.25": "^0.25.12",
-      "basic-ftp@<5.3.1": "^5.3.1",
-      "ip-address@<10.1.1": "^10.1.1",
-      "picomatch@<4.0.4": "^4.0.4",
-      "uuid@<11.1.1": "^11.1.1",
-      "ws@<8.21.0": "^8.21.0",
-      "esbuild@>=0.17.0 <0.28.1": ">=0.28.1",
-      "esbuild@>=0.27.3 <0.28.1": ">=0.28.1",
-      "js-yaml@<=4.1.1": ">=4.2.0",
-      "@babel/core@<=7.29.0": ">=7.29.6",
-      "dompurify@<3.4.11": ">=3.4.11",
-      "@opentelemetry/core@<2.8.0": ">=2.8.0",
-      "undici@>=7.23.0 <7.28.0": "7.28.0"
-    },
-    "ignoredBuiltDependencies": [
-      "core-js"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,37 @@
 packages:
   - 'packages/*'
+
+# pnpm 11 reads these from pnpm-workspace.yaml, not package.json's `pnpm`
+# field (which it now ignores). Migrated verbatim from there on the pnpm
+# 10 → 11 bump — same values, so the lockfile resolution is unchanged.
+
+# Build scripts: pnpm 11 gates every postinstall (secure by default) and
+# records each allow/deny decision here — the pnpm 10 onlyBuiltDependencies /
+# ignoredBuiltDependencies arrays are gone. esbuild + puppeteer genuinely need
+# their native step (the bundler binary; Chromium for the Library cover
+# lookup). core-js's postinstall is just an ad, and unrs-resolver ships
+# prebuilt napi binaries, so both stay denied (matches the pnpm 10 allowlist).
+allowBuilds:
+  esbuild: true
+  puppeteer: true
+  core-js: false
+  unrs-resolver: false
+
+# Security overrides — force-patch transitive advisories across the tree.
+# The source of truth for npm CVEs (the .trivyignore header points here).
+# Keys + values are quoted because they contain YAML-significant chars
+# (@, <, >, spaces).
+overrides:
+  'esbuild@<0.25': '^0.25.12'
+  'basic-ftp@<5.3.1': '^5.3.1'
+  'ip-address@<10.1.1': '^10.1.1'
+  'picomatch@<4.0.4': '^4.0.4'
+  'uuid@<11.1.1': '^11.1.1'
+  'ws@<8.21.0': '^8.21.0'
+  'esbuild@>=0.17.0 <0.28.1': '>=0.28.1'
+  'esbuild@>=0.27.3 <0.28.1': '>=0.28.1'
+  'js-yaml@<=4.1.1': '>=4.2.0'
+  '@babel/core@<=7.29.0': '>=7.29.6'
+  'dompurify@<3.4.11': '>=3.4.11'
+  '@opentelemetry/core@<2.8.0': '>=2.8.0'
+  'undici@>=7.23.0 <7.28.0': '7.28.0'


### PR DESCRIPTION
Trivy was red-failing the api image on 8 pnpm advisories, several with no
10.x backport (e.g. CVE-2026-55697). 11.9.0 fixes all of them, so the
.trivyignore stopgap block is removed.

pnpm 11 stopped reading the `pnpm` field from package.json: the security
overrides + build-script policy move to pnpm-workspace.yaml. The
onlyBuiltDependencies / ignoredBuiltDependencies arrays are gone, replaced by
the `allowBuilds` map — esbuild + puppeteer keep their native build step,
core-js + unrs-resolver stay denied (same effect as before).

Lockfile is byte-identical (no dependency drift). Verified on 11.9.0:
frozen-lockfile install, -r typecheck, -r build (+INTEGRITY), lint, and the
web suite (543) all pass.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
