### PR TITLE
fix(cycle): import MOOD_SCORE_VALUES as a value, not under import type

### DIFF
--- a/packages/web/src/app/flow/Cycle/index.tsx
+++ b/packages/web/src/app/flow/Cycle/index.tsx
@@ -9,7 +9,7 @@
  * and Tabs, same posture as Mood / Goals. Opt-in fertility block is P3.
  */
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import type { CycleFlow, CyclePayload, MOOD_SCORE_VALUES, type MoodScore  } from '@nodea/shared';
+import { type CycleFlow, type CyclePayload, MOOD_SCORE_VALUES, type MoodScore } from '@nodea/shared';
 import type { DecryptedRecord } from '@/core/api/modules/collection-client';
 import { cycleClient } from '@/core/api/modules/cycle';
 import { moodClient } from '@/core/api/modules/mood';


### PR DESCRIPTION
The pre-commit eslint --fix merged the newly-added value import into the
existing `import type { CycleFlow, CyclePayload }` from '@nodea/shared',
producing `import type { …, MOOD_SCORE_VALUES, type MoodScore }`. Under
verbatimModuleSyntax a value cannot sit under `import type`, so tsc failed
in CI (the pre-commit hook rewrote the line after the local typecheck ran).

Rewrite as a single value-level import with inline `type` modifiers on the
type-only names — lint-stable (no duplicate import to merge), so the hook
leaves it alone.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
